### PR TITLE
Add money_in helper for payment url

### DIFF
--- a/lib/lemon_way/helpers/money_in.rb
+++ b/lib/lemon_way/helpers/money_in.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module LemonWay
+  module Helpers
+    module MoneyIn
+      DIRECTKIT_MONEY_IN_URL = \
+        'https://webkit.lemonway.fr/mb/{company_name}/{env}/?moneyintoken={token}'.freeze
+
+      def lemon_way_money_in_url(money_in_token)
+        DIRECTKIT_MONEY_IN_URL
+          .sub('{company_name}', LemonWay.client.company)
+          .sub('{env}', LemonWay.client.env)
+          .sub('{token}', money_in_token)
+      end
+    end
+  end
+end

--- a/lib/lemon_way/railtie.rb
+++ b/lib/lemon_way/railtie.rb
@@ -2,12 +2,14 @@
 
 require 'lemon_way/middleware'
 require 'lemon_way/helpers/forms'
+require 'lemon_way/helpers/money_in'
 
 module LemonWay
   class Railtie < ::Rails::Railtie
     initializer 'lemon_way.configure_rails_initialization' do |app|
       app.middleware.use LemonWay::Middleware
       ActionView::Base.send(:include, LemonWay::Helpers::Forms)
+      ActionView::Base.send(:include, LemonWay::Helpers::MoneyIn)
     end
   end
 end

--- a/lib/lemonway_ruby.rb
+++ b/lib/lemonway_ruby.rb
@@ -9,6 +9,7 @@ require 'lemon_way/form'
 require 'lemon_way/p2p'
 require 'lemon_way/middleware'
 require 'lemon_way/helpers/forms'
+require 'lemon_way/helpers/money_in'
 require 'lemon_way/generators/id'
 require 'lemon_way/railtie' if defined?(Rails)
 

--- a/spec/lemonway/helpers/money_in_spec.rb
+++ b/spec/lemonway/helpers/money_in_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe LemonWay::Helpers::Forms do
+  before { set_lemonway_configuration(company: 'MPA') }
+
+  describe '#lemon_way_money_in_url' do
+    subject(:lemon_way_money_in_url) { Helper.new.lemon_way_money_in_url('ABC') }
+
+    it 'returns the url with the company name' do
+      expect(lemon_way_money_in_url).to include('MPA')
+    end
+
+    it 'returns the url with the env' do
+      expect(lemon_way_money_in_url).to include('dev')
+    end
+
+    it 'returns the url with the token' do
+      expect(lemon_way_money_in_url).to include('?moneyintoken=ABC')
+    end
+  end
+end

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -2,4 +2,5 @@
 
 class Helper
   include LemonWay::Helpers::Forms
+  include LemonWay::Helpers::MoneyIn
 end


### PR DESCRIPTION
After initialize the payment to a wallet, this helper redirects the user to the payment page with the token